### PR TITLE
Narrow permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     },
     "permissions": [],
     "host_permissions": [
-        "*://*/*"
+        // "*://*/*"
     ],
     "background": {
         "service_worker": "service-worker.js"


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#host-permissions

You do not have to declare content script match patterns in host_permissions in order to inject content scripts. However, they are treated as host permissions requests by the Chrome Web Store review process.